### PR TITLE
"cors: true" removed

### DIFF
--- a/AccountsApi/serverless.yml
+++ b/AccountsApi/serverless.yml
@@ -32,7 +32,6 @@ functions:
           path: /{proxy+}
           method: ANY
           private: true
-          cors: true
 resources:
   Resources:
     lambdaExecutionRole:


### PR DESCRIPTION
 Serverless Error ----------------------------------------
 
  An error occurred: AccountsApiLogGroup - /aws/lambda/accounts-api-development already exists in stack arn:aws:cloudformation:*********:************:stack/accounts-api-development/b6cb4350-ce97-11eb-b008-062851e029c8.
 