### PR TITLE
Indexes were defined as attribute in terraform

### DIFF
--- a/terraform/development/dynamodb.tf
+++ b/terraform/development/dynamodb.tf
@@ -9,6 +9,16 @@ resource "aws_dynamodb_table" "accountsapi_dynamodb_table" {
         name              = "id"
         type              = "S"
     }
+	
+    attribute {
+        name              = "account_type"
+        type              = "S"
+    }
+	
+    attribute {
+        name              = "target_id"
+        type              = "S"
+    }
 
     tags = {
         Name              = "accounts-api-${var.environment_name}"

--- a/terraform/production/dynamodb.tf
+++ b/terraform/production/dynamodb.tf
@@ -10,6 +10,16 @@ resource "aws_dynamodb_table" "accountsapi_dynamodb_table" {
         type              = "S"
     }
 
+    attribute {
+        name              = "account_type"
+        type              = "S"
+    }
+	
+    attribute {
+        name              = "target_id"
+        type              = "S"
+    }
+
     tags = {
         Name              = "accounts-api-${var.environment_name}"
         Environment       = var.environment_name

--- a/terraform/staging/dynamodb.tf
+++ b/terraform/staging/dynamodb.tf
@@ -10,6 +10,16 @@ resource "aws_dynamodb_table" "accountsapi_dynamodb_table" {
         type              = "S"
     }
 
+    attribute {
+        name              = "account_type"
+        type              = "S"
+    }
+	
+    attribute {
+        name              = "target_id"
+        type              = "S"
+    }
+
     tags = {
         Name              = "accounts-api-${var.environment_name}"
         Environment       = var.environment_name


### PR DESCRIPTION
## Describe this PR

Creating GSIs and related attributes in deployment, to prevent to lose each GSI after deployment

### *What is the problem we're trying to solve*
- The global secondary indexes will be destroyed after deployment if it isn't included in the terraform state.

### *What changes have we introduced*
- Global index and related attributes added in terraform file