### PR TITLE
Some changes about removing the mandatory of the startDate and endDate

### DIFF
--- a/AccountsApi.Tests/V1/Boundary/Request/AccountRequestTests.cs
+++ b/AccountsApi.Tests/V1/Boundary/Request/AccountRequestTests.cs
@@ -21,7 +21,7 @@ namespace AccountsApi.Tests.V1.Boundary.Request
         public void AccountRequestHasPropertiesSet()
         {
             var accountRequest = typeof(AccountRequest);
-            accountRequest.GetProperties().Length.Should().Be(12);
+            accountRequest.GetProperties().Length.Should().Be(10);
 
             var tenureRequest = typeof(Tenure);
             tenureRequest.GetProperties().Length.Should().Be(4);
@@ -35,11 +35,9 @@ namespace AccountsApi.Tests.V1.Boundary.Request
             Assert.IsType<AccountType>(account.AccountType);
             Assert.IsType<string>(account.AgreementType);
             Assert.IsType<string>(account.CreatedBy);
-            Assert.IsType<DateTime>(account.EndDate);
             Assert.IsType<Guid>(account.ParentAccountId);
             Assert.IsType<string>(account.PaymentReference);
             Assert.IsType<RentGroupType>(account.RentGroupType);
-            Assert.IsType<DateTime>(account.StartDate);
             Assert.IsType<Guid>(account.TargetId);
             Assert.IsType<TargetType>(account.TargetType);
             Assert.IsType<Tenure>(account.Tenure);

--- a/AccountsApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/AccountsApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -203,32 +203,5 @@ namespace AccountsApi.Tests.V1.Gateways
             Assert.All(result, item => item.Should().NotBeNull());
         }
         #endregion
-
-        #region Remove
-        [Fact]
-        public async Task RemoveAsync_WithValidEntry_WorksOnce()
-        {
-            _dynamoDb.Setup(x => x.DeleteAsync(It.IsAny<AccountDbEntity>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
-            Account account = new Account();
-
-            await _gateway.RemoveAsync(account).ConfigureAwait(false);
-
-            _dynamoDb.Verify(x => x.DeleteAsync(It.IsAny<AccountDbEntity>(), It.IsAny<CancellationToken>()), Times.Once());
-        }
-
-        [Fact]
-        public async Task RemoveAsync_WithInValidEntry_WorksOnce()
-        {
-            _dynamoDb.Setup(x => x.DeleteAsync(It.IsAny<AccountDbEntity>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.CompletedTask);
-
-            async Task Func() => await _gateway.RemoveAsync((Account) null).ConfigureAwait(false);
-
-            ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(Func).ConfigureAwait(false);
-            _dynamoDb.Verify(x => x.DeleteAsync(It.IsAny<AccountDbEntity>(), It.IsAny<CancellationToken>()), Times.Never());
-        }
-        #endregion
     }
 }

--- a/AccountsApi.Tests/V1/Helper/Constants.cs
+++ b/AccountsApi.Tests/V1/Helper/Constants.cs
@@ -112,9 +112,7 @@ namespace AccountsApi.Tests.V1.Helper
                 AgreementType = AGREEMENTTYPE,
                 AccountType = ACCOUNTTYPE,
                 CreatedBy = CREATEDBY,
-                EndDate = ENDDATE,
                 RentGroupType = RENTGROUPTYPE,
-                StartDate = STARTDATE,
                 TargetId = TARGETID,
                 TargetType = TARGETTYPE
             };

--- a/AccountsApi.Tests/V1/UseCase/AddUseCaseTests.cs
+++ b/AccountsApi.Tests/V1/UseCase/AddUseCaseTests.cs
@@ -55,8 +55,8 @@ namespace AccountsApi.Tests.V1.UseCase
             result.Should().NotBeNull();
             result.Should().BeEquivalentTo(accountRequest);
             result.Id.Should().NotBeEmpty();
-            result.CreatedAt.Should().BeAfter(DateTime.Now.AddMinutes(-5));
-            result.LastUpdatedAt.Should().BeAfter(DateTime.Now.AddMinutes(-5));
+            result.CreatedAt.Should().BeAfter(DateTime.UtcNow.AddMinutes(-5));
+            result.LastUpdatedAt.Should().BeAfter(DateTime.UtcNow.AddMinutes(-5));
         }
 
         [Fact]

--- a/AccountsApi/V1/Boundary/BaseModel/AccountBaseModel.cs
+++ b/AccountsApi/V1/Boundary/BaseModel/AccountBaseModel.cs
@@ -58,18 +58,6 @@ namespace AccountsApi.V1.Boundary.BaseModel
         public string AgreementType { get; set; }
 
         /// <example>
-        ///     2021-03-29T15:10:37.471Z
-        /// </example>
-        [RequiredDateTime]
-        public DateTime StartDate { get; set; }
-
-        /// <example>
-        ///     2021-03-29T15:10:37.471Z
-        /// </example>
-        [RequiredDateTime]
-        public DateTime EndDate { get; set; }
-
-        /// <example>
         ///     Active
         /// </example>
         [Required]

--- a/AccountsApi/V1/Boundary/BaseModel/AccountResponseModel.cs
+++ b/AccountsApi/V1/Boundary/BaseModel/AccountResponseModel.cs
@@ -20,6 +20,16 @@ namespace AccountsApi.V1.Boundary.BaseModel
         public string LastUpdatedBy { get; set; }
 
         /// <example>
+        ///     2021-03-29T15:10:37.471Z
+        /// </example>
+        public DateTime StartDate { get; set; }
+
+        /// <example>
+        ///     2021-03-29T15:10:37.471Z
+        /// </example>
+        public DateTime EndDate { get; set; }
+
+        /// <example>
         ///     123.01
         /// </example>
         public decimal AccountBalance { get; set; } = 0;

--- a/AccountsApi/V1/Factories/EntityFactory.cs
+++ b/AccountsApi/V1/Factories/EntityFactory.cs
@@ -38,9 +38,7 @@ namespace AccountsApi.V1.Factories
             return new Account
             {
                 AccountStatus = request.AccountStatus,
-                EndDate = request.EndDate,
                 CreatedBy = request.CreatedBy,
-                StartDate = request.StartDate,
                 TargetId = request.TargetId,
                 TargetType = request.TargetType,
                 AccountType = request.AccountType,

--- a/AccountsApi/V1/Gateways/DynamoDbGateway.cs
+++ b/AccountsApi/V1/Gateways/DynamoDbGateway.cs
@@ -32,7 +32,8 @@ namespace AccountsApi.V1.Gateways
         public async Task AddAsync(Account account)
         {
             if (account == null)
-                throw new ArgumentNullException($"{nameof(account).ToString()} model shouldn't be null");
+                throw new ArgumentNullException($"{nameof(account).ToString()} shouldn't be null!");
+
             await _dynamoDbContext.SaveAsync(account.ToDatabase()).ConfigureAwait(false);
         }
 
@@ -79,18 +80,10 @@ namespace AccountsApi.V1.Gateways
             return response.ToAccounts();
         }
 
-        public async Task RemoveAsync(Account account)
-        {
-            if (account == null)
-                throw new ArgumentNullException($"{nameof(account).ToString()} shouldn't be null");
-            await _dynamoDbContext.DeleteAsync(account.ToDatabase()).ConfigureAwait(false);
-        }
-
         public async Task UpdateAsync(Account account)
         {
             if (account == null)
                 throw new ArgumentNullException($"{nameof(account).ToString()} shouldn't be null");
-            account.LastUpdatedAt = DateTime.UtcNow;
             await _dynamoDbContext.SaveAsync(account.ToDatabase()).ConfigureAwait(false);
         }
     }

--- a/AccountsApi/V1/Gateways/IAccountApiGateway.cs
+++ b/AccountsApi/V1/Gateways/IAccountApiGateway.cs
@@ -12,7 +12,6 @@ namespace AccountsApi.V1.Gateways
         public Task<List<Account>> GetAllArrearsAsync(AccountType accountType, string sortBy, Direction direction);
 
         public Task AddAsync(Account account);
-        public Task RemoveAsync(Account account);
         public Task UpdateAsync(Account account);
     }
 }

--- a/AccountsApi/V1/UseCase/AddUseCase.cs
+++ b/AccountsApi/V1/UseCase/AddUseCase.cs
@@ -26,12 +26,18 @@ namespace AccountsApi.V1.UseCase
             if (account == null)
                 throw new ArgumentNullException($"{nameof(account).ToString()} ModelStateExtension shouldn't be null");
 
-            DateTime curDate = DateTime.Now;
+
+            if (account == null)
+                throw new ArgumentNullException($"{nameof(account).ToString()} model shouldn't be null");
+
+            DateTime curDate = DateTime.UtcNow;
             Account domain = account.ToDomain();
             domain.Id = Guid.NewGuid();
             domain.LastUpdatedAt = curDate;
             domain.CreatedAt = curDate;
+            domain.StartDate = curDate;
             domain.LastUpdatedBy = account.CreatedBy;
+
             await _gateway.AddAsync(domain).ConfigureAwait(false);
             var accountSnsMessage = _snsFactory.Create(domain);
             await _snsGateway.Publish(accountSnsMessage).ConfigureAwait(false);

--- a/AccountsApi/V1/UseCase/UpdateUseCase.cs
+++ b/AccountsApi/V1/UseCase/UpdateUseCase.cs
@@ -1,3 +1,4 @@
+using System;
 using AccountsApi.V1.Boundary.Response;
 using AccountsApi.V1.Factories;
 using AccountsApi.V1.Gateways;
@@ -21,6 +22,7 @@ namespace AccountsApi.V1.UseCase
 
         public async Task<AccountResponse> ExecuteAsync(AccountResponse account)
         {
+            account.LastUpdatedAt = DateTime.UtcNow;
             await _gateway.UpdateAsync(account.ToDomain()).ConfigureAwait(false);
             var accountSnsMessage = _snsFactory.Update(account.ToDomain());
             await _snsGateway.Publish(accountSnsMessage).ConfigureAwait(false);


### PR DESCRIPTION
## Link to Click Up ticket

[https://app.clickup.com/t/1gpxq6d](https://app.clickup.com/t/1gpxq6d)

## Describe this PR

In this pr the mandatory of two fields haev been removed
1- StartDate
2- EndDate

because of we don't know when the tenure agreement going to be end at the first time this field should be update in update endpoint, and about the start date it should be replace by the create date time of the account.

#### _Checklist_

- [x] Mandatory of the StartDate removed
- [x] Mandatory of the EndDate removed