### PR TITLE
Removed dynamodb autoscale configuration on prod [due to errors]

### DIFF
--- a/terraform/production/dynamodb.tf
+++ b/terraform/production/dynamodb.tf
@@ -5,40 +5,6 @@ resource "aws_dynamodb_table" "accountsapi_dynamodb_table" {
     write_capacity        = 10
     hash_key              = "id"
 
-    autoscaling_enabled = true
-
-    autoscaling_read = {
-        scale_in_cooldown  = 50
-        scale_out_cooldown = 40
-        target_value       = 45
-        max_capacity       = 10
-    }
-
-    autoscaling_write = {
-        scale_in_cooldown  = 50
-        scale_out_cooldown = 40
-        target_value       = 45
-        max_capacity       = 10
-    }
-
-    autoscaling_indexes = {
-        account_type_dx = {
-            read_max_capacity  = 30
-            read_min_capacity  = 10
-            write_max_capacity = 30
-            write_min_capacity = 10
-        }
-    }
-
-    autoscaling_indexes = {
-        target_id_dx = {
-            read_max_capacity  = 30
-            read_min_capacity  = 10
-            write_max_capacity = 30
-            write_min_capacity = 10
-        }
-    }
-
     attribute {
         name              = "id"
         type              = "S"


### PR DESCRIPTION
# What:
 - Removed the Terraform dynamo database autoscaling configuration _(min/max read/write capacities)_.

# Why (errors):
Because the pipeline was throwing errors regarding these autoscaling configuration lines of code. The 1st error was about autoscaling index being assigned to twice:
| Error 1: "variable already set" |
| ---- |
| ![Same variable twice error](https://user-images.githubusercontent.com/43747286/184611370-754f6b2c-5418-45f9-beeb-13e65b43f36a.png) |

Fixing this error would simply reveal another error, which implies that the specified arguments/blocks are not supported to begin with:

| Error 2: "Unsupported blocks/arguments" |
| ---- |
| ![Unsupported arguments](https://user-images.githubusercontent.com/43747286/184611744-cb1bb609-01fb-499c-aa7b-94625a3dc452.png) |

# Why (it had to be done):
Additionally, there's some evidence suggesting that the index autoscaling was intended to be removed entirely #94 :

| A historic PR for removing index autoscaling |
| ---- |
| ![Removed autoscale configuration](https://user-images.githubusercontent.com/43747286/184612349-84d1914d-0d1c-4946-a727-77c577c1497e.png) |

It's possible that the configuration removed in the PR #94 was simply overlooked.

# Notes:
 - The removal of this terraform code should fix the pipeline error. A clue as to why is in that neither the development, nor staging environments have this configuration within their dynamo database tf files & the deployment to those environments was flawless.
 - Additionally, glancing over all the Hackney APIs updated over the last week seems to show that neither of their terraform files contain the changes like ones removed in this PR. The only autoscaling that they do contain _(when they do)_ is the one that was removed in PR #94 .
 - According to the PR #94 , the removal of autoscaling means no additions to AWS resources.
 - The autoscaling could be fixed by tweaking the file syntax. The used keywords and arguments are correct. However, the official example seems to suggest that the `module` rather than `resource` syntax should be used _([see example](https://github.com/terraform-aws-modules/terraform-aws-dynamodb-table/blob/9ae52b61430e46fc77fbe619bb7eecbd3754315a/examples/autoscaling/main.tf))_. I believe, however, that it's a separate piece of work _(assuming we want to keep autoscaling to begin with)_ due to it possibly needing a mini-spike.