### PR TITLE
Remove the redundant 2nd Auth middleware

### DIFF
--- a/AccountsApi/AccountsApi.csproj
+++ b/AccountsApi/AccountsApi.csproj
@@ -27,7 +27,6 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AspNetCore" Version="2.7.2" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.2" />
     <PackageReference Include="AWSXRayRecorder.Handlers.EntityFramework" Version="1.1.0" />
-    <PackageReference Include="Hackney.Core.Authorization" Version="1.66.0" />
     <PackageReference Include="Hackney.Core.ElasticSearch" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />

--- a/AccountsApi/Startup.cs
+++ b/AccountsApi/Startup.cs
@@ -26,8 +26,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Converters;
 using Swashbuckle.AspNetCore.SwaggerGen;
-using Hackney.Core.Authorization;
-using Hackney.Core.JWT;
 
 namespace AccountsApi
 {
@@ -122,7 +120,6 @@ namespace AccountsApi
             services.ConfigureAws();
             services.ConfigureDynamoDB();
             services.ConfigureElasticSearch(Configuration);
-            services.AddTokenFactory();
 
             RegisterGateways(services);
             RegisterUseCases(services);
@@ -212,7 +209,6 @@ namespace AccountsApi
                         $"{ApiName}-api {apiVersionDescription.GetFormattedApiVersion()}");
                 }
             });
-            app.UseGoogleGroupAuthorization();
             app.UseMiddleware<ExceptionMiddleware>();
             app.UseRouting();
             app.UseEndpoints(endpoints =>


### PR DESCRIPTION
# What:
 - Removing the 2nd Authentication middleware.

# Why:
 - It breaks production by making every request return "403 Forbidden" after it was already authenticated by the now Hackney standard way of authentication _(see more details on the PR #100 description)_.

# Notes:
 - It was deployed as part of PR #81 in a massive dump of code to master. Even after this point, the master branch kept on getting merges, however, it was never deployed past Staging environment. Due to Prod and Stage differing _(technical debt)_ when it comes to authentication, this prod breaking issue was never discovered _(as the only way to do so would be to deploy to prod and see whether it breaks or not)_.