### PR TITLE
Fix pipeline version, auth, and serverless plugin configuration errors.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
       - image: "hashicorp/terraform:1.1.9"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:6.0
+      - image: mcr.microsoft.com/dotnet/sdk:8.0
 
 references:
   workspace_root: &workspace_root "~"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,6 @@
 version: 2.1
 
 orbs:
-  aws-ecr: circleci/aws-ecr@3.0.0
-  aws-cli: circleci/aws-cli@0.1.9
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
+  node: circleci/node@6.3.0
 
 executors:
   docker-python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,11 +109,7 @@ commands:
       - *attach_workspace
       - checkout
       - setup_remote_docker
-      - run:
-          name: Install Node.js
-          command: |
-            curl -sL https://deb.nodesource.com/setup_14.x | bash -
-            apt-get update && apt-get install -y nodejs
+      - node/install
       - run:
           name: Install serverless CLI
           command: npm i -g serverless

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,9 @@ workflows:
           requires:
             - terraform-compliance-development
       - deploy-to-development:
-          context: api-nuget-token-context
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
           requires:
             - terraform-apply-development
           filters:
@@ -288,7 +290,9 @@ workflows:
             branches:
               only: master              
       - deploy-to-staging:
-          context: api-nuget-token-context
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
           requires:
             - terraform-apply-staging
           filters:
@@ -331,7 +335,9 @@ workflows:
             branches:
               only: master
       - deploy-to-production:
-          context: api-nuget-token-context
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
           requires:
             - permit-production-release
           filters:

--- a/AccountsApi/serverless.yml
+++ b/AccountsApi/serverless.yml
@@ -13,7 +13,7 @@ provider:
 package:
   artifact: ./bin/release/net8.0/accounts-api.zip
 
-  plugins:
+plugins:
   - serverless-associate-waf  
 
 functions:


### PR DESCRIPTION
# What:
 - Bump pipeline's dotnet SDK from v6 to v8.
 - Replace node.js installation to use CCI orb instead.
 - Include an extra CCI context for authenticating serverless v4.
 - Fix serverless 'plugin' key being specified at an incorrect YAML tree location.

# Why:
 - Dotnet SDK bumped to match the API's dotnet 8 framework upgrade.
 - Previous pipeline's Node.js version was v14, which was deprecated. So bumped that to v22 implicitly via the Orb.
 - Serverless 4 requires paid license, so it needs an extra CCI context with serverless secret.
 - Serverless plugin key was specified under packages key, so pipeline was giving an error 'plugin' doesn't exist under 'package'. The correct location for 'plugin' is at the root level of YAML.

# Notes:
 - Changes were tried & tested on the `fake_dev` branch.