### PR TITLE
Add CCI feature branch workflow with a terraform preview.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,23 +259,41 @@ workflows:
     jobs:
       - check-code-formatting:
           context: api-nuget-token-context
+          filters:
+            branches:
+              only: development
       - build-and-test:
           context:
             - api-nuget-token-context
             - SonarCloud          
+          filters:
+            branches:
+              only: development
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:
             - build-and-test
+          filters:
+            branches:
+              only: development
       - terraform-init-and-plan-development:
           requires:
             - assume-role-development
+          filters:
+            branches:
+              only: development
       - terraform-compliance-development:
           requires:
             - terraform-init-and-plan-development
+          filters:
+            branches:
+              only: development
       - terraform-apply-development:
           requires:
             - terraform-compliance-development
+          filters:
+            branches:
+              only: development
       - deploy-to-development:
           context:
             - api-nuget-token-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,6 +255,24 @@ jobs:
           stage: "production"
 
 workflows:
+  feature:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - build-and-test:
+          context: 
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
   development:
     jobs:
       - check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,6 +273,43 @@ workflows:
               ignore:
                 - development
                 - master
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - preview-development-terraform:
+          requires:
+            - assume-role-development
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - preview-staging-terraform:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
   development:
     jobs:
       - check-code-formatting:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,7 @@ jobs:
           stage: "production"
 
 workflows:
-  check-and-deploy-development:
+  development:
     jobs:
       - check-code-formatting:
           context: api-nuget-token-context
@@ -285,7 +285,7 @@ workflows:
           filters:
             branches:
               only: development
-  check-and-deploy-staging-and-production:
+  staging-and-production:
     jobs:
       - build-and-test:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,21 @@ jobs:
     steps:
       - terraform-apply:
           environment: "production"
+  preview-development-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "development"
+  preview-staging-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "staging"
+  preview-production-terraform:
+    executor: docker-terraform
+    steps:
+      - terraform-preview:
+          environment: "production"
   deploy-to-development:
     executor: docker-dotnet
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,21 @@ commands:
           paths:
             - .aws
             - project/*
+  terraform-preview:
+    description: "Gives a preview for Terraform configuration changes."
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+            terraform plan
+          name: terraform preview
   terraform-compliance:
     description: "Run Terraform Compliance checks"
     parameters:


### PR DESCRIPTION
# What:
 - Renamed CCI workflows to clearer names.
 - Limit `development` workflow steps to only run on `development` branch triggers.
 - Add a dedicated the `feature` branches' workflow..
 - Add Terraform changes preview to the `feature` branches' workflow.
 - Remove redundant whitespace.

# Why:
 - The `check-and-deploy` portion of the name is meaningless in the context of `development`, `staging`, and `production` environments. These environment inevitably have checks and deployments, so the only thing within the name that matters is: "which environment's workflow is currently running"?
 - Limit development workflow steps to fully separate it out from feature branch checks. Within the `feature` branch we don't really care about one job blocking the other as we want a rapid feedback on every aspect of our changes simultaneously.
 - For the above reason, a dedicated `feature` branches' workflow was added.
 - Added Terraform preview to make application deployments feel less like a buying a bag that could have a cat in it. Our deployments are written in a way where to deploy the application changes, you're forced to deploy the Terraform as well. Nothing bad with that, but that means that if you don't know about a given Terraform drift & you're not looking for it as you're only work on the application changes, you may undo or mess up the infrastructure whilst doing such deployment.
 - Remove redundant whitespace that seems to have been copied into every repository in existence.