### PR TITLE
Release #121, #122, #124, and #125 to `staging`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,8 @@ jobs:
   build-and-test:
     executor: docker-python
     steps:
-      - checkout
+      - checkout:
+          method: full
       - setup_remote_docker
       - run:
           name: build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,174 +253,272 @@ jobs:
     steps:
       - deploy-lambda:
           stage: "production"
+  assume-role-pre-production:
+    executor: docker-python
+    steps:
+      - assume-role-and-persist-workspace:
+          aws-account: $AWS_ACCOUNT_PRE_PRODUCTION
+  terraform-init-and-plan-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-init-then-plan:
+          environment: "pre-production"
+  terraform-compliance-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-compliance:
+          environment: "pre-production"
+  terraform-apply-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-apply:
+          environment: "pre-production"
+  deploy-to-pre-production:
+    executor: docker-dotnet
+    steps:
+      - deploy-lambda:
+          stage: "pre-production"
 
 workflows:
-  feature:
+  # feature:
+  #   jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - development
+  #               - master
+  #     - build-and-test:
+  #         context:
+  #           - api-nuget-token-context
+  #           - SonarCloud
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - development
+  #               - master
+  #     - assume-role-development:
+  #         context: api-assume-role-housing-development-context
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - development
+  #               - master
+  #     - preview-development-terraform:
+  #         requires:
+  #           - assume-role-development
+  #     - assume-role-staging:
+  #         context: api-assume-role-housing-staging-context
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - development
+  #               - master
+  #     - preview-staging-terraform:
+  #         requires:
+  #           - assume-role-staging
+  #     - assume-role-production:
+  #         context: api-assume-role-housing-production-context
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - development
+  #               - master
+  #     - preview-production-terraform:
+  #         requires:
+  #           - assume-role-production
+  # development:
+  #   jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #         filters:
+  #           branches:
+  #             only: development
+  #     - build-and-test:
+  #         context:
+  #           - api-nuget-token-context
+  #           - SonarCloud
+  #         filters:
+  #           branches:
+  #             only: development
+  #     - assume-role-development:
+  #         context: api-assume-role-housing-development-context
+  #         requires:
+  #           - build-and-test
+  #     - terraform-init-and-plan-development:
+  #         requires:
+  #           - assume-role-development
+  #     - terraform-compliance-development:
+  #         requires:
+  #           - terraform-init-and-plan-development
+  #     - terraform-apply-development:
+  #         requires:
+  #           - terraform-compliance-development
+  #     - deploy-to-development:
+  #         context:
+  #           - api-nuget-token-context
+  #           - "Serverless Framework"
+  #         requires:
+  #           - terraform-apply-development
+  # staging-and-production:
+  #   jobs:
+  #     - build-and-test:
+  #         context:
+  #           - api-nuget-token-context
+  #           - SonarCloud
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - assume-role-staging:
+  #         context: api-assume-role-housing-staging-context
+  #         requires:
+  #             - build-and-test
+  #         filters:
+  #            branches:
+  #              only: master
+  #     - terraform-init-and-plan-staging:
+  #         requires:
+  #           - assume-role-staging
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - terraform-compliance-staging:
+  #         requires:
+  #           - terraform-init-and-plan-staging
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - terraform-apply-staging:
+  #         requires:
+  #           - terraform-compliance-staging
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - deploy-to-staging:
+  #         context:
+  #           - api-nuget-token-context
+  #           - "Serverless Framework"
+  #         requires:
+  #           - terraform-apply-staging
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - permit-production-terraform-release:
+  #         type: approval
+  #         requires:
+  #           - deploy-to-staging
+  #     - assume-role-production:
+  #         context: api-assume-role-housing-production-context
+  #         requires:
+  #             - permit-production-terraform-release
+  #         filters:
+  #            branches:
+  #              only: master
+  #     - terraform-init-and-plan-production:
+  #         requires:
+  #           - assume-role-production
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - terraform-compliance-production:
+  #         requires:
+  #           - terraform-init-and-plan-production
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - terraform-apply-production:
+  #         requires:
+  #           - terraform-compliance-production
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - permit-production-release:
+  #         type: approval
+  #         requires:
+  #           - terraform-apply-production
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - deploy-to-production:
+  #         context:
+  #           - api-nuget-token-context
+  #           - "Serverless Framework"
+  #         requires:
+  #           - permit-production-release
+  #         filters:
+  #           branches:
+  #             only: master
+
+  deploy-terraform-pre-production:
     jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
+      - permit-pre-production-terraform-workflow:
+          type: approval
           filters:
             branches:
-              ignore:
-                - development
-                - master
+              only: ts-2045-add-pre-production-workflows
+      - assume-role-pre-production:
+          context: api-assume-role-housing-pre-production-context
+          requires:
+            - permit-pre-production-terraform-workflow
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - terraform-init-and-plan-pre-production:
+          requires:
+            - assume-role-pre-production
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - terraform-compliance-pre-production:
+          requires:
+            - terraform-init-and-plan-pre-production
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - permit-pre-production-terraform-deployment:
+          type: approval
+          requires:
+            - terraform-compliance-pre-production
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - terraform-apply-pre-production:
+          requires:
+            - permit-pre-production-terraform-deployment
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+
+  deploy-code-pre-production:
+    jobs:
+      - permit-pre-production-code-workflow:
+          type: approval
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
       - build-and-test:
-          context:
+          requires:
+            - permit-pre-production-code-workflow
+          context: 
             - api-nuget-token-context
             - SonarCloud
           filters:
             branches:
-              ignore:
-                - development
-                - master
-      - assume-role-development:
-          context: api-assume-role-housing-development-context
-          filters:
-            branches:
-              ignore:
-                - development
-                - master
-      - preview-development-terraform:
-          requires:
-            - assume-role-development
-      - assume-role-staging:
-          context: api-assume-role-housing-staging-context
-          filters:
-            branches:
-              ignore:
-                - development
-                - master
-      - preview-staging-terraform:
-          requires:
-            - assume-role-staging
-      - assume-role-production:
-          context: api-assume-role-housing-production-context
-          filters:
-            branches:
-              ignore:
-                - development
-                - master
-      - preview-production-terraform:
-          requires:
-            - assume-role-production
-  development:
-    jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
-          filters:
-            branches:
-              only: development
-      - build-and-test:
-          context:
-            - api-nuget-token-context
-            - SonarCloud
-          filters:
-            branches:
-              only: development
-      - assume-role-development:
-          context: api-assume-role-housing-development-context
+              only: ts-2045-add-pre-production-workflows
+      - assume-role-pre-production:
+          context: api-assume-role-housing-pre-production-context
           requires:
             - build-and-test
-      - terraform-init-and-plan-development:
-          requires:
-            - assume-role-development
-      - terraform-compliance-development:
-          requires:
-            - terraform-init-and-plan-development
-      - terraform-apply-development:
-          requires:
-            - terraform-compliance-development
-      - deploy-to-development:
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - deploy-to-pre-production:
           context:
-            - api-nuget-token-context
-            - "Serverless Framework"
+          - api-nuget-token-context
+          - "Serverless Framework"
           requires:
-            - terraform-apply-development
-  staging-and-production:
-    jobs:
-      - build-and-test:
-          context:
-            - api-nuget-token-context
-            - SonarCloud
+            - assume-role-pre-production        
           filters:
             branches:
-              only: master
-      - assume-role-staging:
-          context: api-assume-role-housing-staging-context
-          requires:
-              - build-and-test
-          filters:
-             branches:
-               only: master
-      - terraform-init-and-plan-staging:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: master
-      - terraform-compliance-staging:
-          requires:
-            - terraform-init-and-plan-staging
-          filters:
-            branches:
-              only: master
-      - terraform-apply-staging:
-          requires:
-            - terraform-compliance-staging
-          filters:
-            branches:
-              only: master
-      - deploy-to-staging:
-          context:
-            - api-nuget-token-context
-            - "Serverless Framework"
-          requires:
-            - terraform-apply-staging
-          filters:
-            branches:
-              only: master
-      - permit-production-terraform-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-      - assume-role-production:
-          context: api-assume-role-housing-production-context
-          requires:
-              - permit-production-terraform-release
-          filters:
-             branches:
-               only: master
-      - terraform-init-and-plan-production:
-          requires:
-            - assume-role-production
-          filters:
-            branches:
-              only: master
-      - terraform-compliance-production:
-          requires:
-            - terraform-init-and-plan-production
-          filters:
-            branches:
-              only: master
-      - terraform-apply-production:
-          requires:
-            - terraform-compliance-production
-          filters:
-            branches:
-              only: master
-      - permit-production-release:
-          type: approval
-          requires:
-            - terraform-apply-production
-          filters:
-            branches:
-              only: master
-      - deploy-to-production:
-          context:
-            - api-nuget-token-context
-            - "Serverless Framework"
-          requires:
-            - permit-production-release
-          filters:
-            branches:
-              only: master
+              only: ts-2045-add-pre-production-workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,175 +280,175 @@ jobs:
           stage: "pre-production"
 
 workflows:
-  feature:
-    jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
-          filters:
-            branches:
-              ignore:
-                - development
-                - master
-      - build-and-test:
-          context:
-            - api-nuget-token-context
-            - SonarCloud
-          filters:
-            branches:
-              ignore:
-                - development
-                - master
-      - assume-role-development:
-          context: api-assume-role-housing-development-context
-          filters:
-            branches:
-              ignore:
-                - development
-                - master
-      - preview-development-terraform:
-          requires:
-            - assume-role-development
-      - assume-role-staging:
-          context: api-assume-role-housing-staging-context
-          filters:
-            branches:
-              ignore:
-                - development
-                - master
-      - preview-staging-terraform:
-          requires:
-            - assume-role-staging
-      - assume-role-production:
-          context: api-assume-role-housing-production-context
-          filters:
-            branches:
-              ignore:
-                - development
-                - master
-      - preview-production-terraform:
-          requires:
-            - assume-role-production
-  development:
-    jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
-          filters:
-            branches:
-              only: development
-      - build-and-test:
-          context:
-            - api-nuget-token-context
-            - SonarCloud
-          filters:
-            branches:
-              only: development
-      - assume-role-development:
-          context: api-assume-role-housing-development-context
-          requires:
-            - build-and-test
-      - terraform-init-and-plan-development:
-          requires:
-            - assume-role-development
-      - terraform-compliance-development:
-          requires:
-            - terraform-init-and-plan-development
-      - terraform-apply-development:
-          requires:
-            - terraform-compliance-development
-      - deploy-to-development:
-          context:
-            - api-nuget-token-context
-            - "Serverless Framework"
-          requires:
-            - terraform-apply-development
-  staging-and-production:
-    jobs:
-      - build-and-test:
-          context:
-            - api-nuget-token-context
-            - SonarCloud
-          filters:
-            branches:
-              only: master
-      - assume-role-staging:
-          context: api-assume-role-housing-staging-context
-          requires:
-              - build-and-test
-          filters:
-             branches:
-               only: master
-      - terraform-init-and-plan-staging:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: master
-      - terraform-compliance-staging:
-          requires:
-            - terraform-init-and-plan-staging
-          filters:
-            branches:
-              only: master
-      - terraform-apply-staging:
-          requires:
-            - terraform-compliance-staging
-          filters:
-            branches:
-              only: master
-      - deploy-to-staging:
-          context:
-            - api-nuget-token-context
-            - "Serverless Framework"
-          requires:
-            - terraform-apply-staging
-          filters:
-            branches:
-              only: master
-      - permit-production-terraform-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-      - assume-role-production:
-          context: api-assume-role-housing-production-context
-          requires:
-              - permit-production-terraform-release
-          filters:
-             branches:
-               only: master
-      - terraform-init-and-plan-production:
-          requires:
-            - assume-role-production
-          filters:
-            branches:
-              only: master
-      - terraform-compliance-production:
-          requires:
-            - terraform-init-and-plan-production
-          filters:
-            branches:
-              only: master
-      - terraform-apply-production:
-          requires:
-            - terraform-compliance-production
-          filters:
-            branches:
-              only: master
-      - permit-production-release:
-          type: approval
-          requires:
-            - terraform-apply-production
-          filters:
-            branches:
-              only: master
-      - deploy-to-production:
-          context:
-            - api-nuget-token-context
-            - "Serverless Framework"
-          requires:
-            - permit-production-release
-          filters:
-            branches:
-              only: master
+  # feature:
+  #   jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - development
+  #               - master
+  #     - build-and-test:
+  #         context:
+  #           - api-nuget-token-context
+  #           - SonarCloud
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - development
+  #               - master
+  #     - assume-role-development:
+  #         context: api-assume-role-housing-development-context
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - development
+  #               - master
+  #     - preview-development-terraform:
+  #         requires:
+  #           - assume-role-development
+  #     - assume-role-staging:
+  #         context: api-assume-role-housing-staging-context
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - development
+  #               - master
+  #     - preview-staging-terraform:
+  #         requires:
+  #           - assume-role-staging
+  #     - assume-role-production:
+  #         context: api-assume-role-housing-production-context
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - development
+  #               - master
+  #     - preview-production-terraform:
+  #         requires:
+  #           - assume-role-production
+  # development:
+  #   jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #         filters:
+  #           branches:
+  #             only: development
+  #     - build-and-test:
+  #         context:
+  #           - api-nuget-token-context
+  #           - SonarCloud
+  #         filters:
+  #           branches:
+  #             only: development
+  #     - assume-role-development:
+  #         context: api-assume-role-housing-development-context
+  #         requires:
+  #           - build-and-test
+  #     - terraform-init-and-plan-development:
+  #         requires:
+  #           - assume-role-development
+  #     - terraform-compliance-development:
+  #         requires:
+  #           - terraform-init-and-plan-development
+  #     - terraform-apply-development:
+  #         requires:
+  #           - terraform-compliance-development
+  #     - deploy-to-development:
+  #         context:
+  #           - api-nuget-token-context
+  #           - "Serverless Framework"
+  #         requires:
+  #           - terraform-apply-development
+  # staging-and-production:
+  #   jobs:
+  #     - build-and-test:
+  #         context:
+  #           - api-nuget-token-context
+  #           - SonarCloud
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - assume-role-staging:
+  #         context: api-assume-role-housing-staging-context
+  #         requires:
+  #             - build-and-test
+  #         filters:
+  #            branches:
+  #              only: master
+  #     - terraform-init-and-plan-staging:
+  #         requires:
+  #           - assume-role-staging
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - terraform-compliance-staging:
+  #         requires:
+  #           - terraform-init-and-plan-staging
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - terraform-apply-staging:
+  #         requires:
+  #           - terraform-compliance-staging
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - deploy-to-staging:
+  #         context:
+  #           - api-nuget-token-context
+  #           - "Serverless Framework"
+  #         requires:
+  #           - terraform-apply-staging
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - permit-production-terraform-release:
+  #         type: approval
+  #         requires:
+  #           - deploy-to-staging
+  #     - assume-role-production:
+  #         context: api-assume-role-housing-production-context
+  #         requires:
+  #             - permit-production-terraform-release
+  #         filters:
+  #            branches:
+  #              only: master
+  #     - terraform-init-and-plan-production:
+  #         requires:
+  #           - assume-role-production
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - terraform-compliance-production:
+  #         requires:
+  #           - terraform-init-and-plan-production
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - terraform-apply-production:
+  #         requires:
+  #           - terraform-compliance-production
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - permit-production-release:
+  #         type: approval
+  #         requires:
+  #           - terraform-apply-production
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - deploy-to-production:
+  #         context:
+  #           - api-nuget-token-context
+  #           - "Serverless Framework"
+  #         requires:
+  #           - permit-production-release
+  #         filters:
+  #           branches:
+  #             only: master
 
   deploy-terraform-pre-production:
     jobs:
@@ -456,39 +456,39 @@ workflows:
           type: approval
           filters:
             branches:
-              only: master
+              only: ts-2045-add-new-sg-for-lambda
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - permit-pre-production-terraform-workflow
           filters:
             branches:
-              only: master
+              only: ts-2045-add-new-sg-for-lambda
       - terraform-init-and-plan-pre-production:
           requires:
             - assume-role-pre-production
           filters:
             branches:
-              only: master
+              only: ts-2045-add-new-sg-for-lambda
       - terraform-compliance-pre-production:
           requires:
             - terraform-init-and-plan-pre-production
           filters:
             branches:
-              only: master
+              only: ts-2045-add-new-sg-for-lambda
       - permit-pre-production-terraform-deployment:
           type: approval
           requires:
             - terraform-compliance-pre-production
           filters:
             branches:
-              only: master
+              only: ts-2045-add-new-sg-for-lambda
       - terraform-apply-pre-production:
           requires:
             - permit-pre-production-terraform-deployment
           filters:
             branches:
-              only: master
+              only: ts-2045-add-new-sg-for-lambda
 
   deploy-code-pre-production:
     jobs:
@@ -498,14 +498,14 @@ workflows:
             - SonarCloud
           filters:
             branches:
-              only: master
+              only: ts-2045-add-new-sg-for-lambda
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - build-and-test
           filters:
             branches:
-              only: master
+              only: ts-2045-add-new-sg-for-lambda
       - deploy-to-pre-production:
           context:
           - api-nuget-token-context
@@ -514,4 +514,4 @@ workflows:
             - assume-role-pre-production        
           filters:
             branches:
-              only: master
+              only: ts-2045-add-new-sg-for-lambda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,175 +280,175 @@ jobs:
           stage: "pre-production"
 
 workflows:
-  # feature:
-  #   jobs:
-  #     - check-code-formatting:
-  #         context: api-nuget-token-context
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - development
-  #               - master
-  #     - build-and-test:
-  #         context:
-  #           - api-nuget-token-context
-  #           - SonarCloud
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - development
-  #               - master
-  #     - assume-role-development:
-  #         context: api-assume-role-housing-development-context
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - development
-  #               - master
-  #     - preview-development-terraform:
-  #         requires:
-  #           - assume-role-development
-  #     - assume-role-staging:
-  #         context: api-assume-role-housing-staging-context
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - development
-  #               - master
-  #     - preview-staging-terraform:
-  #         requires:
-  #           - assume-role-staging
-  #     - assume-role-production:
-  #         context: api-assume-role-housing-production-context
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - development
-  #               - master
-  #     - preview-production-terraform:
-  #         requires:
-  #           - assume-role-production
-  # development:
-  #   jobs:
-  #     - check-code-formatting:
-  #         context: api-nuget-token-context
-  #         filters:
-  #           branches:
-  #             only: development
-  #     - build-and-test:
-  #         context:
-  #           - api-nuget-token-context
-  #           - SonarCloud
-  #         filters:
-  #           branches:
-  #             only: development
-  #     - assume-role-development:
-  #         context: api-assume-role-housing-development-context
-  #         requires:
-  #           - build-and-test
-  #     - terraform-init-and-plan-development:
-  #         requires:
-  #           - assume-role-development
-  #     - terraform-compliance-development:
-  #         requires:
-  #           - terraform-init-and-plan-development
-  #     - terraform-apply-development:
-  #         requires:
-  #           - terraform-compliance-development
-  #     - deploy-to-development:
-  #         context:
-  #           - api-nuget-token-context
-  #           - "Serverless Framework"
-  #         requires:
-  #           - terraform-apply-development
-  # staging-and-production:
-  #   jobs:
-  #     - build-and-test:
-  #         context:
-  #           - api-nuget-token-context
-  #           - SonarCloud
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - assume-role-staging:
-  #         context: api-assume-role-housing-staging-context
-  #         requires:
-  #             - build-and-test
-  #         filters:
-  #            branches:
-  #              only: master
-  #     - terraform-init-and-plan-staging:
-  #         requires:
-  #           - assume-role-staging
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - terraform-compliance-staging:
-  #         requires:
-  #           - terraform-init-and-plan-staging
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - terraform-apply-staging:
-  #         requires:
-  #           - terraform-compliance-staging
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - deploy-to-staging:
-  #         context:
-  #           - api-nuget-token-context
-  #           - "Serverless Framework"
-  #         requires:
-  #           - terraform-apply-staging
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - permit-production-terraform-release:
-  #         type: approval
-  #         requires:
-  #           - deploy-to-staging
-  #     - assume-role-production:
-  #         context: api-assume-role-housing-production-context
-  #         requires:
-  #             - permit-production-terraform-release
-  #         filters:
-  #            branches:
-  #              only: master
-  #     - terraform-init-and-plan-production:
-  #         requires:
-  #           - assume-role-production
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - terraform-compliance-production:
-  #         requires:
-  #           - terraform-init-and-plan-production
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - terraform-apply-production:
-  #         requires:
-  #           - terraform-compliance-production
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - permit-production-release:
-  #         type: approval
-  #         requires:
-  #           - terraform-apply-production
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - deploy-to-production:
-  #         context:
-  #           - api-nuget-token-context
-  #           - "Serverless Framework"
-  #         requires:
-  #           - permit-production-release
-  #         filters:
-  #           branches:
-  #             only: master
+  feature:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - preview-development-terraform:
+          requires:
+            - assume-role-development
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - preview-staging-terraform:
+          requires:
+            - assume-role-staging
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - preview-production-terraform:
+          requires:
+            - assume-role-production
+  development:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              only: development
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              only: development
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          requires:
+            - build-and-test
+      - terraform-init-and-plan-development:
+          requires:
+            - assume-role-development
+      - terraform-compliance-development:
+          requires:
+            - terraform-init-and-plan-development
+      - terraform-apply-development:
+          requires:
+            - terraform-compliance-development
+      - deploy-to-development:
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
+          requires:
+            - terraform-apply-development
+  staging-and-production:
+    jobs:
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              only: master
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          requires:
+              - build-and-test
+          filters:
+             branches:
+               only: master
+      - terraform-init-and-plan-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only: master
+      - terraform-compliance-staging:
+          requires:
+            - terraform-init-and-plan-staging
+          filters:
+            branches:
+              only: master
+      - terraform-apply-staging:
+          requires:
+            - terraform-compliance-staging
+          filters:
+            branches:
+              only: master
+      - deploy-to-staging:
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
+          requires:
+            - terraform-apply-staging
+          filters:
+            branches:
+              only: master
+      - permit-production-terraform-release:
+          type: approval
+          requires:
+            - deploy-to-staging
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          requires:
+              - permit-production-terraform-release
+          filters:
+             branches:
+               only: master
+      - terraform-init-and-plan-production:
+          requires:
+            - assume-role-production
+          filters:
+            branches:
+              only: master
+      - terraform-compliance-production:
+          requires:
+            - terraform-init-and-plan-production
+          filters:
+            branches:
+              only: master
+      - terraform-apply-production:
+          requires:
+            - terraform-compliance-production
+          filters:
+            branches:
+              only: master
+      - permit-production-release:
+          type: approval
+          requires:
+            - terraform-apply-production
+          filters:
+            branches:
+              only: master
+      - deploy-to-production:
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
+          requires:
+            - permit-production-release
+          filters:
+            branches:
+              only: master
 
   deploy-terraform-pre-production:
     jobs:
@@ -456,39 +456,24 @@ workflows:
           type: approval
           filters:
             branches:
-              only: ts-2045-add-new-sg-for-lambda
+              only: master
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - permit-pre-production-terraform-workflow
-          filters:
-            branches:
-              only: ts-2045-add-new-sg-for-lambda
       - terraform-init-and-plan-pre-production:
           requires:
             - assume-role-pre-production
-          filters:
-            branches:
-              only: ts-2045-add-new-sg-for-lambda
       - terraform-compliance-pre-production:
           requires:
             - terraform-init-and-plan-pre-production
-          filters:
-            branches:
-              only: ts-2045-add-new-sg-for-lambda
       - permit-pre-production-terraform-deployment:
           type: approval
           requires:
             - terraform-compliance-pre-production
-          filters:
-            branches:
-              only: ts-2045-add-new-sg-for-lambda
       - terraform-apply-pre-production:
           requires:
             - permit-pre-production-terraform-deployment
-          filters:
-            branches:
-              only: ts-2045-add-new-sg-for-lambda
 
   deploy-code-pre-production:
     jobs:
@@ -498,20 +483,14 @@ workflows:
             - SonarCloud
           filters:
             branches:
-              only: ts-2045-add-new-sg-for-lambda
+              only: master
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - build-and-test
-          filters:
-            branches:
-              only: ts-2045-add-new-sg-for-lambda
       - deploy-to-pre-production:
           context:
           - api-nuget-token-context
           - "Serverless Framework"
           requires:
             - assume-role-pre-production        
-          filters:
-            branches:
-              only: ts-2045-add-new-sg-for-lambda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,175 +280,175 @@ jobs:
           stage: "pre-production"
 
 workflows:
-  # feature:
-  #   jobs:
-  #     - check-code-formatting:
-  #         context: api-nuget-token-context
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - development
-  #               - master
-  #     - build-and-test:
-  #         context:
-  #           - api-nuget-token-context
-  #           - SonarCloud
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - development
-  #               - master
-  #     - assume-role-development:
-  #         context: api-assume-role-housing-development-context
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - development
-  #               - master
-  #     - preview-development-terraform:
-  #         requires:
-  #           - assume-role-development
-  #     - assume-role-staging:
-  #         context: api-assume-role-housing-staging-context
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - development
-  #               - master
-  #     - preview-staging-terraform:
-  #         requires:
-  #           - assume-role-staging
-  #     - assume-role-production:
-  #         context: api-assume-role-housing-production-context
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - development
-  #               - master
-  #     - preview-production-terraform:
-  #         requires:
-  #           - assume-role-production
-  # development:
-  #   jobs:
-  #     - check-code-formatting:
-  #         context: api-nuget-token-context
-  #         filters:
-  #           branches:
-  #             only: development
-  #     - build-and-test:
-  #         context:
-  #           - api-nuget-token-context
-  #           - SonarCloud
-  #         filters:
-  #           branches:
-  #             only: development
-  #     - assume-role-development:
-  #         context: api-assume-role-housing-development-context
-  #         requires:
-  #           - build-and-test
-  #     - terraform-init-and-plan-development:
-  #         requires:
-  #           - assume-role-development
-  #     - terraform-compliance-development:
-  #         requires:
-  #           - terraform-init-and-plan-development
-  #     - terraform-apply-development:
-  #         requires:
-  #           - terraform-compliance-development
-  #     - deploy-to-development:
-  #         context:
-  #           - api-nuget-token-context
-  #           - "Serverless Framework"
-  #         requires:
-  #           - terraform-apply-development
-  # staging-and-production:
-  #   jobs:
-  #     - build-and-test:
-  #         context:
-  #           - api-nuget-token-context
-  #           - SonarCloud
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - assume-role-staging:
-  #         context: api-assume-role-housing-staging-context
-  #         requires:
-  #             - build-and-test
-  #         filters:
-  #            branches:
-  #              only: master
-  #     - terraform-init-and-plan-staging:
-  #         requires:
-  #           - assume-role-staging
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - terraform-compliance-staging:
-  #         requires:
-  #           - terraform-init-and-plan-staging
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - terraform-apply-staging:
-  #         requires:
-  #           - terraform-compliance-staging
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - deploy-to-staging:
-  #         context:
-  #           - api-nuget-token-context
-  #           - "Serverless Framework"
-  #         requires:
-  #           - terraform-apply-staging
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - permit-production-terraform-release:
-  #         type: approval
-  #         requires:
-  #           - deploy-to-staging
-  #     - assume-role-production:
-  #         context: api-assume-role-housing-production-context
-  #         requires:
-  #             - permit-production-terraform-release
-  #         filters:
-  #            branches:
-  #              only: master
-  #     - terraform-init-and-plan-production:
-  #         requires:
-  #           - assume-role-production
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - terraform-compliance-production:
-  #         requires:
-  #           - terraform-init-and-plan-production
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - terraform-apply-production:
-  #         requires:
-  #           - terraform-compliance-production
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - permit-production-release:
-  #         type: approval
-  #         requires:
-  #           - terraform-apply-production
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - deploy-to-production:
-  #         context:
-  #           - api-nuget-token-context
-  #           - "Serverless Framework"
-  #         requires:
-  #           - permit-production-release
-  #         filters:
-  #           branches:
-  #             only: master
+  feature:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - preview-development-terraform:
+          requires:
+            - assume-role-development
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - preview-staging-terraform:
+          requires:
+            - assume-role-staging
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          filters:
+            branches:
+              ignore:
+                - development
+                - master
+      - preview-production-terraform:
+          requires:
+            - assume-role-production
+  development:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              only: development
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              only: development
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          requires:
+            - build-and-test
+      - terraform-init-and-plan-development:
+          requires:
+            - assume-role-development
+      - terraform-compliance-development:
+          requires:
+            - terraform-init-and-plan-development
+      - terraform-apply-development:
+          requires:
+            - terraform-compliance-development
+      - deploy-to-development:
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
+          requires:
+            - terraform-apply-development
+  staging-and-production:
+    jobs:
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              only: master
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          requires:
+              - build-and-test
+          filters:
+             branches:
+               only: master
+      - terraform-init-and-plan-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only: master
+      - terraform-compliance-staging:
+          requires:
+            - terraform-init-and-plan-staging
+          filters:
+            branches:
+              only: master
+      - terraform-apply-staging:
+          requires:
+            - terraform-compliance-staging
+          filters:
+            branches:
+              only: master
+      - deploy-to-staging:
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
+          requires:
+            - terraform-apply-staging
+          filters:
+            branches:
+              only: master
+      - permit-production-terraform-release:
+          type: approval
+          requires:
+            - deploy-to-staging
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          requires:
+              - permit-production-terraform-release
+          filters:
+             branches:
+               only: master
+      - terraform-init-and-plan-production:
+          requires:
+            - assume-role-production
+          filters:
+            branches:
+              only: master
+      - terraform-compliance-production:
+          requires:
+            - terraform-init-and-plan-production
+          filters:
+            branches:
+              only: master
+      - terraform-apply-production:
+          requires:
+            - terraform-compliance-production
+          filters:
+            branches:
+              only: master
+      - permit-production-release:
+          type: approval
+          requires:
+            - terraform-apply-production
+          filters:
+            branches:
+              only: master
+      - deploy-to-production:
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
+          requires:
+            - permit-production-release
+          filters:
+            branches:
+              only: master
 
   deploy-terraform-pre-production:
     jobs:
@@ -456,63 +456,56 @@ workflows:
           type: approval
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: master
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - permit-pre-production-terraform-workflow
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: master
       - terraform-init-and-plan-pre-production:
           requires:
             - assume-role-pre-production
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: master
       - terraform-compliance-pre-production:
           requires:
             - terraform-init-and-plan-pre-production
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: master
       - permit-pre-production-terraform-deployment:
           type: approval
           requires:
             - terraform-compliance-pre-production
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: master
       - terraform-apply-pre-production:
           requires:
             - permit-pre-production-terraform-deployment
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: master
 
   deploy-code-pre-production:
     jobs:
-      - permit-pre-production-code-workflow:
-          type: approval
-          filters:
-            branches:
-              only: ts-2045-add-pre-production-workflows
       - build-and-test:
-          requires:
-            - permit-pre-production-code-workflow
           context: 
             - api-nuget-token-context
             - SonarCloud
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: master
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - build-and-test
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: master
       - deploy-to-pre-production:
           context:
           - api-nuget-token-context
@@ -521,4 +514,4 @@ workflows:
             - assume-role-pre-production        
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: master

--- a/AccountsApi/serverless.yml
+++ b/AccountsApi/serverless.yml
@@ -165,9 +165,8 @@ custom:
         - subnet-0beb266003a56ca82
         - subnet-06a697d86a9b6ed01
     pre-production:
-      #using default sg for now, like stg and prod
       securityGroupIds:
-        - sg-0ba6244706c2077c9
+        - sg-0b36ec6c5c92626c7
       subnetIds:
         - subnet-08aa35159a8706faa
         - subnet-0b848c5b14f841dfb

--- a/AccountsApi/serverless.yml
+++ b/AccountsApi/serverless.yml
@@ -139,7 +139,7 @@ resources:
 custom:
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-gateway-lambda-authorizer
-    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
+    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
     pre-production: arn:aws:lambda:eu-west-2:578479666894:function:api-auth-verify-token-new-pre-production-apiauthverifytokennew
   associateWaf:

--- a/AccountsApi/serverless.yml
+++ b/AccountsApi/serverless.yml
@@ -138,7 +138,7 @@ resources:
                           - 'table/Accounts/index/*'
 custom:
   authorizerArns:
-    development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
+    development: arn:aws:lambda:eu-west-2:859159924354:function:api-gateway-lambda-authorizer
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
     pre-production: arn:aws:lambda:eu-west-2:578479666894:function:api-auth-verify-token-new-pre-production-apiauthverifytokennew

--- a/AccountsApi/serverless.yml
+++ b/AccountsApi/serverless.yml
@@ -94,15 +94,6 @@ resources:
                           - Ref: 'AWS::Region'
                           - Ref: 'AWS::AccountId'
                           - 'log-group:/aws/lambda/*:*:*'
-                - Effect: "Allow"
-                  Action:
-                    - "s3:PutObject"
-                    - "s3:GetObject"
-                  Resource:
-                    Fn::Join:
-                      - ""
-                      - - "arn:aws:s3:::"
-                        - "Ref": "ServerlessDeploymentBucket"
           - PolicyName: lambdaInvocation
             PolicyDocument:
               Version: '2012-10-17'
@@ -150,6 +141,7 @@ custom:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
+    pre-production: arn:aws:lambda:eu-west-2:578479666894:function:api-auth-verify-token-new-pre-production-apiauthverifytokennew
   associateWaf:
     name: Platform_APIs_Web_ACL
     version: V2
@@ -172,6 +164,13 @@ custom:
       subnetIds:
         - subnet-0beb266003a56ca82
         - subnet-06a697d86a9b6ed01
+    pre-production:
+      #using default sg for now, like stg and prod
+      securityGroupIds:
+        - sg-0ba6244706c2077c9
+      subnetIds:
+        - subnet-08aa35159a8706faa
+        - subnet-0b848c5b14f841dfb
 
 #plugins:
 #  - serverless-step-functions

--- a/terraform/pre-production/aws_security_group.tf
+++ b/terraform/pre-production/aws_security_group.tf
@@ -1,3 +1,9 @@
+data "aws_vpc" "pre_production_vpc" {
+  tags = {
+    Name = "housing-pre-prod-pre-prod"
+  }
+}
+
 resource "aws_security_group" "lambda" {
   name                   = "accounts-api-lambda-sg"
   description            = "Security group used by the Accounts API lambda function"

--- a/terraform/pre-production/aws_security_group.tf
+++ b/terraform/pre-production/aws_security_group.tf
@@ -1,0 +1,16 @@
+resource "aws_security_group" "lambda" {
+  name                   = "accounts-api-lambda-sg"
+  description            = "Security group used by the Accounts API lambda function"
+  vpc_id                 = data.aws_vpc.pre_production_vpc.id
+  revoke_rules_on_delete = true
+}
+
+resource "aws_security_group_rule" "egress_https" {
+  security_group_id = aws_security_group.lambda.id
+  type              = "egress"
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow egress on port 443"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "TCP"
+}

--- a/terraform/pre-production/aws_ssm_parameter.tf
+++ b/terraform/pre-production/aws_ssm_parameter.tf
@@ -1,0 +1,23 @@
+resource "aws_ssm_parameter" "elasticsearch_domain" {
+  name  = "/housing-search-api/pre-production/elasticsearch-domain"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+resource "aws_ssm_parameter" "auth_required_google_groups" {
+  name  = "/housing-finance/pre-production/authorization/required-google-groups"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}

--- a/terraform/pre-production/dynamodb.tf
+++ b/terraform/pre-production/dynamodb.tf
@@ -1,0 +1,47 @@
+resource "aws_dynamodb_table" "accountsapi_dynamodb_table" {
+  name           = "Accounts"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 10
+  write_capacity = 10
+  hash_key       = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  attribute {
+    name = "account_type"
+    type = "S"
+  }
+
+  attribute {
+    name = "target_id"
+    type = "S"
+  }
+
+  tags = merge(
+    local.default_tags,
+    { BackupPolicy = "Dev", Backup = false, Confidentiality = "Internal" }
+  )
+
+  global_secondary_index {
+    name            = "account_type_dx"
+    hash_key        = "account_type"
+    write_capacity  = 10
+    read_capacity   = 10
+    projection_type = "ALL"
+  }
+
+  global_secondary_index {
+    name            = "target_id_dx"
+    hash_key        = "target_id"
+    write_capacity  = 10
+    read_capacity   = 10
+    projection_type = "ALL"
+  }
+
+  point_in_time_recovery {
+    enabled = false
+  }
+}

--- a/terraform/pre-production/main.tf
+++ b/terraform/pre-production/main.tf
@@ -40,7 +40,7 @@ resource "aws_sns_topic" "accounts_topic" {
 }
 
 resource "aws_ssm_parameter" "new_account_created_sns_arn" {
-  name  = "/sns-topic/pre-production/account_created/arn"
+  name  = "/sns-topic/pre-production/accounts/arn"
   type  = "String"
   value = aws_sns_topic.accounts_topic.arn
 }

--- a/terraform/pre-production/main.tf
+++ b/terraform/pre-production/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+locals {
+  default_tags = {
+    Name              = "account-api-${var.environment_name}"
+    Environment       = var.environment_name
+    terraform-managed = true
+    project_name      = var.project_name
+    Application       = "MTFH Housing Pre-Production"
+    TeamEmail         = "developementteam@hackney.gov.uk"
+  }
+}
+
+terraform {
+  backend "s3" {
+    bucket         = "housing-pre-production-terraform-state"
+    encrypt        = true
+    region         = "eu-west-2"
+    key            = "services/accounts-api/state"
+    dynamodb_table = "housing-pre-production-terraform-state-lock"
+  }
+}
+
+resource "aws_sns_topic" "accounts_topic" {
+  name                        = "accounts.fifo"
+  fifo_topic                  = true
+  content_based_deduplication = true
+  kms_master_key_id           = "alias/aws/sns"
+}
+
+resource "aws_ssm_parameter" "new_account_created_sns_arn" {
+  name  = "/sns-topic/pre-production/account_created/arn"
+  type  = "String"
+  value = aws_sns_topic.accounts_topic.arn
+}

--- a/terraform/pre-production/terraform-compliance/dynamodb.feature
+++ b/terraform/pre-production/terraform-compliance/dynamodb.feature
@@ -1,0 +1,20 @@
+Feature: DynamoDB is used as our NoSQL database service
+  In order to improve security
+  As engineers
+  We'll use ensure our DynamoDB tables are configured correctly
+
+  Scenario: Ensure BackupPolicy tag is present
+    Given I have aws_dynamodb_table defined
+    Then it must contain tags
+    And it must contain BackupPolicy
+
+  Scenario: Ensure point in time recovery disabled
+    Given I have aws_dynamodb_table defined
+    Then it must contain point_in_time_recovery
+    And its enabled property must be false
+
+  Scenario: Ensure a maximum of 2 GSIs
+    Given I have aws_dynamodb_table defined
+    When it contains global_secondary_index
+    When I count them
+    Then I expect the result is less and equal to 2

--- a/terraform/pre-production/terraform-compliance/sns.feature
+++ b/terraform/pre-production/terraform-compliance/sns.feature
@@ -1,0 +1,8 @@
+Feature: SNS is used as our notification service
+  In order to improve security
+  As engineers
+  We'll use ensure our SNS topics are configured correctly
+
+  Scenario: Ensure encryption is enabled
+    Given I have aws_sns_topic defined
+    Then it must contain kms_master_key_id

--- a/terraform/pre-production/variables.tf
+++ b/terraform/pre-production/variables.tf
@@ -1,0 +1,9 @@
+variable "environment_name" {
+  type    = string
+  default = "pre-prod"
+}
+
+variable "project_name" {
+  type    = string
+  default = "Housing-Pre-Production"
+}


### PR DESCRIPTION
# What:
 - Release #121 to `staging`.
 - Release #122 to `staging`.
 - Release #124 to `staging`.
 - Release #125 to `staging`.

# Why:
 - Primary release target it #125 - it's a part of piece of work of rolling out the Cognito authentication flow to `staging`.

# Notes:
 - Most of these PRs are pre-production environment related. No green light has been given thus far to dismantle this BTA related piece of work, so it's left as is.